### PR TITLE
Add retry support for certain upload failures

### DIFF
--- a/src/__specs__/cli.spec.js
+++ b/src/__specs__/cli.spec.js
@@ -6,7 +6,8 @@ import getRawBody from 'raw-body';
 const CLI_INDEX = './bin/logrocket';
 const FIXTURE_PATH = './test/fixtures/';
 
-const executeCommand = async (cmd, { env = '' } = {}) => {
+const executeCommand = async (cmdAsStringOrArray, { env = '' } = {}) => {
+  const cmd = Array.isArray(cmdAsStringOrArray) ? cmdAsStringOrArray.join(' ') : cmdAsStringOrArray;
   return new Promise(resolve => {
     exec(
       `${env} ${CLI_INDEX} ${cmd}`,
@@ -26,11 +27,24 @@ describe('CLI dispatch tests', function cliTests() {
   let matchedRequests;
 
   const addExpectRequest = (url, opts) => {
-    expectRequests[url] = {
+    if (!expectRequests[url]) {
+      expectRequests[url] = [];
+    }
+
+    expectRequests[url].push({
       body: {},
       status: 200,
       ...opts,
-    };
+    });
+  };
+
+  const addArtifactRequest = () => {
+    const uploadID = (100000 + Math.floor(Math.random() * 999999)).toString(16);
+    addExpectRequest('/v1/orgs/org/apps/app/releases/1.0.2/artifacts/', {
+      status: 200,
+      body: { signed_url: `http://localhost:8818/upload/${uploadID}` },
+    });
+    addExpectRequest(`/upload/${uploadID}`, { status: 200 });
   };
 
   const addCliStatusMessage = ({ message = '', status = 204 } = {}) => {
@@ -59,15 +73,16 @@ describe('CLI dispatch tests', function cliTests() {
     };
     server = createServer(async (req, res) => {
       const parts = parse(req.url);
+      const expected = expectRequests[parts.pathname] || [];
 
-      if (expectRequests[parts.pathname]) {
+      if (expected && expected.length) {
         const body = await getRawBody(req);
         const req2 = req;
 
         req2.body = body.toString();
         matchedRequests.push(simplifyRequest(req2));
 
-        const request = expectRequests[parts.pathname];
+        const request = expected.shift();
 
         res.writeHead(request.status, { 'Content-Type': 'application/json' });
         res.write(JSON.stringify(request.body));
@@ -265,12 +280,10 @@ describe('CLI dispatch tests', function cliTests() {
 
   it('should upload the passed directory', mochaAsync(async () => {
     addCliStatusMessage();
-    addExpectRequest('/v1/orgs/org/apps/app/releases/1.0.2/artifacts/', {
-      status: 200,
-      body: { signed_url: 'http://localhost:8818/upload/' },
-    });
 
-    addExpectRequest('/upload/', { status: 200 });
+    addArtifactRequest();
+    addArtifactRequest();
+    addArtifactRequest();
 
     const result = await executeCommand(`upload -k org:app:secret -r 1.0.2 --apihost="http://localhost:8818" ${FIXTURE_PATH}`);
 
@@ -320,12 +333,10 @@ describe('CLI dispatch tests', function cliTests() {
 
   it('should support a custom url prefix', mochaAsync(async () => {
     addCliStatusMessage();
-    addExpectRequest('/v1/orgs/org/apps/app/releases/1.0.2/artifacts/', {
-      status: 200,
-      body: { signed_url: 'http://localhost:8818/upload/' },
-    });
 
-    addExpectRequest('/upload/', { status: 200 });
+    addArtifactRequest();
+    addArtifactRequest();
+    addArtifactRequest();
 
     const result = await executeCommand(`upload -k org:app:secret -r 1.0.2 --apihost="http://localhost:8818" ${FIXTURE_PATH} --url-prefix="~/public"`);
 
@@ -360,12 +371,8 @@ describe('CLI dispatch tests', function cliTests() {
 
   it('should upload the passed file', mochaAsync(async () => {
     addCliStatusMessage();
-    addExpectRequest('/v1/orgs/org/apps/app/releases/1.0.2/artifacts/', {
-      status: 200,
-      body: { signed_url: 'http://localhost:8818/upload/' },
-    });
 
-    addExpectRequest('/upload/', { status: 200 });
+    addArtifactRequest();
 
     const result = await executeCommand(`upload -k org:app:secret -r 1.0.2 --apihost="http://localhost:8818" ${FIXTURE_PATH}subdir/one.js`);
 
@@ -388,12 +395,9 @@ describe('CLI dispatch tests', function cliTests() {
 
   it('should upload the passed files', mochaAsync(async () => {
     addCliStatusMessage();
-    addExpectRequest('/v1/orgs/org/apps/app/releases/1.0.2/artifacts/', {
-      status: 200,
-      body: { signed_url: 'http://localhost:8818/upload/' },
-    });
 
-    addExpectRequest('/upload/', { status: 200 });
+    addArtifactRequest();
+    addArtifactRequest();
 
     const result = await executeCommand(`upload -k org:app:secret -r 1.0.2 --apihost="http://localhost:8818" ${FIXTURE_PATH}subdir/one.js ${FIXTURE_PATH}two.jsx`);
 
@@ -438,5 +442,61 @@ describe('CLI dispatch tests', function cliTests() {
 
     expect(result.err.code).to.equal(1);
     expect(result.stderr).to.contain('Some error to show');
+  }));
+
+  it('should retry failed uploads', mochaAsync(async () => {
+    addCliStatusMessage();
+
+    addExpectRequest('/v1/orgs/org/apps/app/releases/1.0.2/artifacts/', {
+      status: 200,
+      body: { signed_url: 'http://localhost:8818/upload/' },
+    });
+    addExpectRequest('/upload/', { status: 429 });
+    addExpectRequest('/upload/', { status: 500 });
+    addExpectRequest('/upload/', { status: 502 });
+    addExpectRequest('/upload/', { status: 503 });
+    addExpectRequest('/upload/', { status: 504 });
+    addExpectRequest('/upload/', { status: 200 });
+
+    const result = await executeCommand([
+      'upload',
+      '-k org:app:secret',
+      '-r 1.0.2',
+      '--apihost="http://localhost:8818"',
+      '--max-retries 5',
+      '--max-retry-delay 100',
+      `${FIXTURE_PATH}subdir/one.js`,
+    ]);
+
+    expect(result.err).to.be.null();
+    expect(result.stdout).to.contain('Found 1 file');
+    expect(matchedRequests).to.have.length(8);
+    expect(unmatchedRequests).to.have.length(0);
+  }));
+
+  it('should stop retrying after the configured maximum', mochaAsync(async () => {
+    addCliStatusMessage();
+
+    addExpectRequest('/v1/orgs/org/apps/app/releases/1.0.2/artifacts/', {
+      status: 200,
+      body: { signed_url: 'http://localhost:8818/upload/' },
+    });
+    addExpectRequest('/upload/', { status: 429 });
+    addExpectRequest('/upload/', { status: 500 });
+
+    const result = await executeCommand([
+      'upload',
+      '-k org:app:secret',
+      '-r 1.0.2',
+      '--apihost="http://localhost:8818"',
+      '--max-retries 1',
+      '--max-retry-delay 100',
+      `${FIXTURE_PATH}subdir/one.js`,
+    ]);
+
+    expect(result.err.message).to.contain('Failed to upload: one.js');
+    expect(result.stdout).to.contain('Found 1 file');
+    expect(matchedRequests).to.have.length(4);
+    expect(unmatchedRequests).to.have.length(0);
   }));
 });

--- a/src/commands/upload.js
+++ b/src/commands/upload.js
@@ -35,6 +35,17 @@ export const builder = (args) => {
       'gcs-token': 'gcs-bucket',
       'gcs-bucket': 'gcs-token',
     })
+    .option('max-retries', {
+      type: 'number',
+      describe: 'Failed upload retry limit (0 disables)',
+      default: 0,
+    })
+    .option('max-retry-delay', {
+      type: 'number',
+      describe: 'Maximum delay between retries in ms',
+      default: 30000,
+      describe: false,
+    })
     .help('help');
 };
 
@@ -95,6 +106,8 @@ export const handler = async (args) => {
       release,
       filepath,
       contents: createReadStream(path),
+      maxRetries: args['max-retries'],
+      maxRetryDelay: args['max-retry-delay'],
     };
 
     try {

--- a/src/commands/upload.js
+++ b/src/commands/upload.js
@@ -44,7 +44,6 @@ export const builder = (args) => {
       type: 'number',
       describe: 'Maximum delay between retries in ms',
       default: 30000,
-      describe: false,
     })
     .help('help');
 };


### PR DESCRIPTION
GCS can randomly fail uploads with 502s (and other retryable statuses). This adds an optional `--max-retries` flag with a naive exponential backoff (up to 30s wait by default).