### PR TITLE
Only upload files

### DIFF
--- a/src/commands/upload.js
+++ b/src/commands/upload.js
@@ -56,10 +56,13 @@ async function gatherFiles(paths) {
     return new Promise(resolve => {
       glob('**/*.{js,jsx,js.map}', { cwd: realPath }, async (err, files) => {
         for (const file of files) {
-          map.push({
-            path: join(realPath, file),
-            name: file,
-          });
+          const filePath = join(realPath, file);
+          if (statSync(filePath).isFile()) {
+            map.push({
+              path: filePath,
+              name: file,
+            });
+          }
         }
 
         resolve();


### PR DESCRIPTION
If a folder ends with `.js`, `.jsx`, or `.js.map`, it will attempt to upload it, throwing an error:

```
Error: EISDIR: illegal operation on a directory, read
Emitted 'error' event on ReadStream instance at:
    at internal/fs/streams.js:202:14
    at FSReqCallback.wrapper [as oncomplete] (fs.js:528:5) {
  errno: -4068,
  code: 'EISDIR',
  syscall: 'read'
}
```