### PR TITLE
Add more context to 403 response errors

### DIFF
--- a/src/__specs__/responseStatusMessage.spec.js
+++ b/src/__specs__/responseStatusMessage.spec.js
@@ -1,0 +1,56 @@
+import ResponseStatusMessage from '../responseStatusMessage';
+
+describe('ResponseStatusMessage', () => {
+  describe('#hasAdvice', () => {
+    describe('when status code is 403', () => {
+      it('is true', () => {
+        // eslint-disable-next-line no-unused-expressions
+        expect(new ResponseStatusMessage({ code: 403, text: 'Forbidden' }).hasAdvice).to.be.true;
+      });
+    });
+
+    describe('when status code is not 403', () => {
+      describe('when status code is 200', () => {
+        it('is false', () => {
+          // eslint-disable-next-line no-unused-expressions
+          expect(new ResponseStatusMessage({ code: 200, text: 'Success' }).hasAdvice).to.be.false;
+        });
+      });
+    });
+  });
+
+  describe('#advice', () => {
+    describe('when status code is 403', () => {
+      it('returns advice for recovering from a Forbidden error', () => {
+        expect(new ResponseStatusMessage({ code: 403, text: 'Forbidden' }).advice).
+          to.equal('Was a valid API key provided for an organization & application you have access to?');
+      });
+    });
+
+    describe('when status code is not 403', () => {
+      describe('when status code is 200', () => {
+        it('returns undefined', () => {
+          // eslint-disable-next-line no-unused-expressions
+          expect(new ResponseStatusMessage({ code: 200, text: 'Success' }).advice).to.be.undefined;
+        });
+      });
+    });
+  });
+
+  describe('#toString', () => {
+    describe('when status code is 403', () => {
+      it('returns advice for recovering from a Forbidden error', () => {
+        expect(new ResponseStatusMessage({ code: 403, text: 'Forbidden' }).toString()).
+          to.equal('403 Forbidden - Was a valid API key provided for an organization & application you have access to?');
+      });
+    });
+
+    describe('when status code is not 403', () => {
+      describe('when status code is 200', () => {
+        it('returns status code and status text', () => {
+          expect(new ResponseStatusMessage({ code: 200, text: 'Success' }).toString()).to.equal('200 Success');
+        });
+      });
+    });
+  });
+});

--- a/src/formatError.js
+++ b/src/formatError.js
@@ -1,9 +1,16 @@
+import ResponseStatusMessage from './responseStatusMessage';
+
 export default async function formatError(res, { verbose = false } = {}) {
   if (res.status < 300) {
     return;
   }
 
-  console.error(`${res.status} ${res.statusText}`);
+  console.error(
+    new ResponseStatusMessage({
+      code: res.status,
+      text: res.statusText,
+    }).toString()
+  );
 
   const body = await res.text();
 

--- a/src/responseStatusMessage.js
+++ b/src/responseStatusMessage.js
@@ -1,0 +1,28 @@
+const RESPONSE_STATUS_CODES_TO_ADVICE = Object.freeze({
+  403: 'Was a valid API key provided for an organization & application you have access to?',
+});
+
+class ResponseStatusMessage {
+  constructor({ code, text }) {
+    this.code = code;
+    this.text = text;
+  }
+
+  get advice() {
+    return RESPONSE_STATUS_CODES_TO_ADVICE[this.code];
+  }
+
+  get hasAdvice() {
+    return this.code in RESPONSE_STATUS_CODES_TO_ADVICE;
+  }
+
+  toString() {
+    const formattedMessage = `${this.code} ${this.text}`;
+    if (this.hasAdvice) {
+      return `${formattedMessage} - ${this.advice}`;
+    }
+    return formattedMessage;
+  }
+}
+
+export default ResponseStatusMessage;


### PR DESCRIPTION
### Summary

Closes #1 

Adds the ability to provide additional context to a response, in this particular case, `Forbidden` responses without having to pass the `verbose` flag.

```bash
Creating release: test1 ...
Could not create release: test1
403 Forbidden - Was a valid API key provided for an organization & application you have access to?
```