### PR TITLE
Add possibility to use the CLI programmatically

### DIFF
--- a/bin/logrocket
+++ b/bin/logrocket
@@ -1,3 +1,35 @@
 #!/usr/bin/env node
 
-require('../dist/index.js');
+import yargs from 'yargs';
+
+process.on('unhandledRejection', (err) => {
+  console.error(err.message);
+  process.exit(1);
+});
+
+yargs // eslint-disable-line no-unused-expressions
+  .usage('\nUsage: logrocket [-k <apikey>] <command> [<args>]')
+  .env('LOGROCKET')
+  .alias('h', 'help')
+  .option('k', {
+    alias: 'apikey',
+    type: 'string',
+    describe: 'Your LogRocket API key',
+    demand: 'You must provide a LogRocket API key.',
+    global: true,
+    requiresArg: true,
+  })
+  .option('apihost', { // testing param to override api url
+    type: 'string',
+    describe: false,
+  })
+  .option('v', { // for debugging
+    alias: 'verbose',
+    boolean: true,
+    describe: false,
+  })
+  .commandDir('../src/commands')
+  .help()
+  .demand(1, 'Missing command, expected `release` or `upload`')
+  .recommendCommands()
+  .argv;

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./src');
+module.exports = require('./dist');

--- a/src/apiClient.js
+++ b/src/apiClient.js
@@ -21,7 +21,6 @@ class ApiClient {
 
   async _makeRequest({ url, data }) {
     const [orgSlug, appSlug] = this.apikey.split(':');
-
     return fetch(`${this.apihost}/v1/orgs/${orgSlug}/apps/${appSlug}/${url}/`, {
       method: 'POST',
       headers: this.headers,

--- a/src/commands/release.js
+++ b/src/commands/release.js
@@ -17,6 +17,9 @@ export const builder = (args) => {
 };
 
 export const handler = async ({ version, strict, apikey, apihost, verbose }) => {
+  if (!version) throw new Error('Missing release version');
+  if (!apikey) throw new Error('Missing api key');
+
   console.info(`Creating release: ${version} ...`);
 
   const client = apiClient({ apikey, apihost });

--- a/src/commands/upload.js
+++ b/src/commands/upload.js
@@ -71,7 +71,14 @@ async function gatherFiles(paths) {
 }
 
 export const handler = async (args) => {
-  const { paths, release, apikey, apihost, verbose, urlPrefix } = args;
+  const { release, apikey, apihost, verbose, urlPrefix = '' } = args;
+  let { paths } = args;
+  if (!release) throw new Error('Missing release version');
+  if (!paths) throw new Error('Missing paths');
+  if (!apikey) throw new Error('Missing api key');
+  if (typeof paths === 'string') {
+    paths = [paths];
+  }
 
   console.info(`Preparing to upload sourcemaps for release ${release} ...`);
   console.info('Gathering file list...');

--- a/src/index.js
+++ b/src/index.js
@@ -1,33 +1,4 @@
-import yargs from 'yargs';
+const { handler: releaseHandler } = require('./commands/release');
+const { handler: uploadHandler } = require('./commands/upload');
 
-process.on('unhandledRejection', (err) => {
-  console.error(err.message);
-  process.exit(1);
-});
-
-yargs // eslint-disable-line no-unused-expressions
-  .usage('\nUsage: logrocket [-k <apikey>] <command> [<args>]')
-  .env('LOGROCKET')
-  .alias('h', 'help')
-  .option('k', {
-    alias: 'apikey',
-    type: 'string',
-    describe: 'Your LogRocket API key',
-    demand: 'You must provide a LogRocket API key.',
-    global: true,
-    requiresArg: true,
-  })
-  .option('apihost', { // testing param to override api url
-    type: 'string',
-    describe: false,
-  })
-  .option('v', { // for debugging
-    alias: 'verbose',
-    boolean: true,
-    describe: false,
-  })
-  .commandDir('commands')
-  .help()
-  .demand(1, 'Missing command, expected `release` or `upload`')
-  .recommendCommands()
-  .argv;
+module.exports = { release: releaseHandler, upload: uploadHandler };


### PR DESCRIPTION
This pull request adds the possibility to use the CLI programmatically. This is useful for using LogRocket as part of a webpack flow for example.

Here is an associated repository for a webpack plugin using my fork: https://github.com/NicolasBonduel/webpack-logrocket-plugin

This change was inspired by this Sentry plugin: https://github.com/getsentry/sentry-webpack-plugin