### PR TITLE
bump version to 0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+# 0.13
+- Adds support for `max-retries` and `max-retry-delay` options to upload command, to automatically retry failed sourcemap requests to LogRocket.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logrocket-cli",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Command line tool for [LogRocket](https://logrocket.com/).",
   "main": "index.js",
   "author": "Logrocket <support@logrocket.com> (https://logrocket.com/)",


### PR DESCRIPTION
- Adds support for `max-retries` and `max-retry-delay` options to upload command.

Also added a changelog