### PR TITLE
fix(api): add duplex configuration to fetch

### DIFF
--- a/src/apiClient.js
+++ b/src/apiClient.js
@@ -52,6 +52,7 @@ class ApiClient {
       method: 'POST',
       headers: this.headers,
       body: JSON.stringify(data),
+      duplex: 'half',
     });
   }
 
@@ -110,6 +111,7 @@ class ApiClient {
       maxRetryDelay,
       method: 'PUT',
       body: contents,
+      duplex: 'half',
     });
 
     if (this._gcsBucket) {
@@ -123,6 +125,7 @@ class ApiClient {
           name: fileData.name,
           bucket: this._gcsBucket,
         }),
+        duplex: 'half',
       });
     }
 


### PR DESCRIPTION
Node sneakily introduced a change to the fetch API that now requires that the `duplex` option be set on all requests with contain a payload body: https://github.com/nodejs/node/issues/46221 , which means that the CLI now fails on node >18.13, >19.1, 20, with the following exception:
```
RequestInit: duplex option is required when sending a body.

Exited with code exit status 1
```

This configures all fetch requests with bodies to set the duplex option to the only value that is allowed by the spec for now, which is `"half"`. This should have no impact on older node versions since it's the only option available, but will allow the CLI to run on those newer versions without throwing an error.