### PR TITLE
Allow upload command to gather .map and .bundle filetypes

### DIFF
--- a/src/gatherFiles.js
+++ b/src/gatherFiles.js
@@ -4,7 +4,7 @@ import glob from 'glob';
 import { statSync } from 'fs';
 import { handleFileError } from './errorTypes';
 
-export async function gatherFiles(paths, { globString = '**/*.{js,jsx,js.map}' } = {}) {
+export async function gatherFiles(paths, { globString = '**/*.{js,jsx,map,bundle}' } = {}) {
   const map = [];
 
   await Promise.all(paths.map((path) => {


### PR DESCRIPTION
We previously added the upload-mobile command to allow for uploading of debug files for iOS and Android apps, and already supported uploading javascript sourcemaps - however, React-Native applications generate sourcemaps with [different file extensions](https://reactnative.dev/docs/next/debugging-release-builds#enabling-source-maps) than we currently accept for the existing `upload` command. This PR enables uploading of .bundle and .map (not just .js.map) files in the `gatherFiles` code.