### PR TITLE
Clean up build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "lint": "eslint src/",
     "prebuild": "rm -rf dist",
-    "build": "babel src --out-dir dist --ignore \"src/__specs__/*\"",
+    "build": "babel src --out-dir dist",
+    "prepublish": "rm -rf dist/__specs__",
     "test:mocha": "mocha --opts test/mocha.opts dist/**/*.spec.js",
     "test": "npm run build && npm run test:mocha"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "eslint src/",
     "prebuild": "rm -rf dist",
     "build": "babel src --out-dir dist",
-    "prepublish": "rm -rf dist/__specs__",
+    "prepare": "rm -rf dist/__specs__",
     "test:mocha": "mocha --opts test/mocha.opts dist/**/*.spec.js",
     "test": "npm run build && npm run test:mocha"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "scripts": {
     "lint": "eslint src/",
-    "build": "babel src --out-dir dist",
+    "prebuild": "rm -rf dist",
+    "build": "babel src --out-dir dist --ignore \"src/__specs__/*\"",
     "test:mocha": "mocha --opts test/mocha.opts dist/**/*.spec.js",
     "test": "npm run build && npm run test:mocha"
   },


### PR DESCRIPTION
Just a couple quality of life improvements while we're here. Cleans the `dist` directory before building in the event there are any stale artifacts there, e.g. source maps, and remove test files before publishing.