### PR TITLE
[API-37] fix handling of pats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,6 @@
 
 # 0.15.2
 - Support artifact uploads for Expo-specific releases
+
+# 0.16.0
+- Add support for new API keys (personal access tokens)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "logrocket-cli",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "logrocket-cli",
-      "version": "0.15.2",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logrocket-cli",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "Command line tool for [LogRocket](https://logrocket.com/).",
   "main": "index.js",
   "author": "Logrocket <support@logrocket.com> (https://logrocket.com/)",

--- a/src/__specs__/apiClient.spec.js
+++ b/src/__specs__/apiClient.spec.js
@@ -54,4 +54,22 @@ describe('CLI apiClient tests', () => {
     const gCloud = fetchMock.lastOptions('gcloud');
     expect(gCloud.body).to.equal('stuff!');
   }));
+
+  it('should handle pats', mochaAsync(async () => {
+    const patClient = apiClient({
+      apikey: 'pat:myorg:myapp:secret',
+      apihost: 'https://example.com',
+    });
+
+    fetchMock.post(
+      'https://example.com/v1/orgs/myorg/apps/myapp/releases/',
+      () => 200,
+    );
+
+    await patClient.createRelease({ version: '1.0.0' });
+
+    expect(fetchMock.calls().matched).to.have.length(1);
+    const opts = fetchMock.lastCall()[1];
+    expect(opts.headers).to.have.property('Authorization', 'Token pat:myorg:myapp:secret');
+  }));
 });

--- a/src/apiClient.js
+++ b/src/apiClient.js
@@ -46,7 +46,19 @@ class ApiClient {
   }
 
   async _makeRequest({ url, data }) {
-    const [orgSlug, appSlug] = this.apikey.split(':');
+    const parts = this.apikey.split(':');
+
+    let orgSlug;
+    let appSlug;
+    if (parts.length === 4) {
+      [, orgSlug, appSlug] = parts;
+    } else if (parts.length === 3) {
+      [orgSlug, appSlug] = parts;
+    } else {
+      throw new Error(
+        'Invalid API key format: expected org:app:secret or pat:org:app:secret',
+      );
+    }
 
     return fetch(`${this.apihost}/v1/orgs/${orgSlug}/apps/${appSlug}/${url}/`, {
       method: 'POST',


### PR DESCRIPTION
Allows either new PAT-style or old app-wide API keys to be used.